### PR TITLE
add nitro snipe server blacklist

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -13,7 +13,8 @@
     "max": 2,
     "cooldown": 24,
     "main_sniper": true,
-    "delay": true
+    "delay": true,
+    "blacklist_servers": []
   },
   "giveaway": {
     "enable": true,

--- a/sniper.go
+++ b/sniper.go
@@ -39,10 +39,11 @@ type Settings struct {
 		Alts string `json:"alts"`
 	} `json:"status"`
 	Nitro struct {
-		Max        int  `json:"max"`
-		Cooldown   int  `json:"cooldown"`
-		MainSniper bool `json:"main_sniper"`
-		Delay      bool `json:"delay"`
+		Max              int      `json:"max"`
+		Cooldown         int      `json:"cooldown"`
+		MainSniper       bool     `json:"main_sniper"`
+		Delay            bool     `json:"delay"`
+		BlacklistServers []string `json:"blacklist_servers"`
 	} `json:"nitro"`
 	Giveaway struct {
 		Enable           bool     `json:"enable"`
@@ -819,7 +820,7 @@ func findHost(s *discordgo.Session, m *discordgo.MessageCreate) string {
 
 func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 
-	if reGiftLink.Match([]byte(m.Content)) && SniperRunning {
+	if reGiftLink.Match([]byte(m.Content)) && SniperRunning && !contains(settings.Nitro.BlacklistServers, m.GuildID) {
 		checkGiftLink(s, m, m.Content, time.Now())
 	} else if settings.Giveaway.Enable && !contains(settings.Giveaway.BlacklistServers, m.GuildID) && (strings.Contains(strings.ToLower(m.Content), "**giveaway**") || (strings.Contains(strings.ToLower(m.Content), "react with") && strings.Contains(strings.ToLower(m.Content), "giveaway"))) && m.Author.Bot {
 		content, _ := json.Marshal(m)


### PR DESCRIPTION
Adds an option to blacklist servers from sniping nitro gifts

This is mainly intended for servers you're active in, if you have no nitro yet. Your close friends finding out you sniped a Nitro gift could be devastating to them, so to avoid this, this option was added.

Mainly just a personal preference thing, but others could benefit from this too :p

tested with fake and legit codes, none got checked.