### PR TITLE
Added a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:alpine3.14 AS builder
+
+RUN apk add build-base --no-cache
+
+WORKDIR app
+
+COPY . .
+
+RUN apk add --no-cache gcc libc-dev alsa-lib-dev \
+	&& go mod download \
+	&& go build
+
+FROM alpine:3.14 AS final
+
+WORKDIR app
+
+COPY --from=builder /go/app/NitroSniperGo /app/NitroSniperGo
+
+RUN apk add --no-cache alsa-lib-dev
+
+CMD ["/app/NitroSniperGo"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM golang:alpine3.14 AS builder
 
-RUN apk add build-base --no-cache
-
 WORKDIR app
 
 COPY . .


### PR DESCRIPTION
Now NitroSniperGo can be used as a docker image.

Docker CLI:
```
docker run --name NitroSniperGo -d -v `pwd`/settings.json:/app/settings.json NitroSniperGo:lastest
```